### PR TITLE
move environment within first 1M, and some FreeBSD

### DIFF
--- a/api/api.c
+++ b/api/api.c
@@ -307,6 +307,11 @@ static int API_dev_close(va_list ap)
 	if (!err)
 		di->state = DEV_STA_CLOSED;
 
+	if (dcache_status())
+		flush_dcache_all();
+	if (icache_status())
+		invalidate_icache_all();
+
 	return err;
 }
 

--- a/include/configs/armada_38x.h
+++ b/include/configs/armada_38x.h
@@ -583,10 +583,9 @@ extern int nand_get_env_offs(void);
 //	#define CONFIG_SYS_MMC_ENV_PART			1 /* Valid for MMC/eMMC for separating boot image and env */
 	#define CONFIG_SYS_MMC_ENV_DEV			0
 	#define CONFIG_ENV_SECT_SIZE			0x200
-	#define CONFIG_ENV_SIZE					0x80000
-	/* For SD - reserve 1 LBA for MBR + 1M for u-boot image. The MMC/eMMC boot image starts @ LBA-0.
-	   As result in MMC/eMMC case it will be a 1 sector gap between u-boot image and environment */
-	#define CONFIG_ENV_OFFSET				(_1M + CONFIG_ENV_SECT_SIZE)
+	#define CONFIG_ENV_SIZE					0x2000
+	/* stay within first 1M */
+	#define CONFIG_ENV_OFFSET				(_1M - CONFIG_ENV_SIZE)
 	#define CONFIG_ENV_ADDR					CONFIG_ENV_OFFSET
 	#define MONITOR_HEADER_LEN				0x200
 	#define CONFIG_SYS_MONITOR_BASE			0


### PR DESCRIPTION
The first change is about the u-boot environment location. It is always nice to leave as little space unused as possible.
By moving it before the first 1M, it will not overlap the default start sector for the first partition on an sdcard, which is 2048 (1M).
This would also be cool for SPI flash, but I don't care at this time.

The second change makes sure that FreeBSD can boot. I am not aware of any other application that uses the u-boot API directly, so to my knowledge this change only affects FreeBSD, the only user.