### PR TITLE
Modify post gpio config callback

### DIFF
--- a/board/mv_ebu/a38x/armada_38x_family/boardEnv/mvBoardEnvLib.c
+++ b/board/mv_ebu/a38x/armada_38x_family/boardEnv/mvBoardEnvLib.c
@@ -196,10 +196,6 @@ MV_VOID mvBoardEnvInit(MV_VOID)
 	mvGppTypeSet(0, 0xFFFFFFFF, board->gppOutEnValLow);
 	mvGppTypeSet(1, 0xFFFFFFFF, board->gppOutEnValMid);
 	mvGppTypeSet(2, 0xFFFFFFFF, board->gppOutEnValHigh);
-
-	/* Call callback function for board specific post GPP configuration */
-	if (board->gppPostConfigCallBack)
-		board->gppPostConfigCallBack(board);
 }
 
 /*******************************************************************************
@@ -1526,6 +1522,9 @@ MV_VOID mvBoardConfigWrite(void)
 			i++;
 		}
 	}
+	/* Call callback function for board specific post GPP configuration */
+	if (board->gppPostConfigCallBack)
+		board->gppPostConfigCallBack(board);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
GPIO callback to board specific function was implemented in the wrong place.
Originally it was defined after gpios has been configured, but this is not good
enough since the MPPs (pin muxing) hasn't been configured yet.

This patch moves the call to the callback function after both GPIOs and MPPs
has been configured.

The bug was found when implementing resetting the on usom phy which uses
GPIO19 (valid on ClearFog boards rev 2.1 and newer).